### PR TITLE
Add "Identity Mappings in Deep Residual Networks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Total 85 papers except for the papers in *Hardware / Software* and *Papers Worth
 - Pixel Recurrent Neural Networks (2016), A. van den Oord et al. *(DeepMind)* [[pdf]](http://arxiv.org/pdf/1601.06759v2.pdf)
 - LSTM: A search space odyssey (2015), K. Greff et al. [[pdf]](http://arxiv.org/pdf/1503.04069)
 - Training very deep networks (2015), R. Srivastava et al. [[pdf]](http://papers.nips.cc/paper/5850-training-very-deep-networks.pdf)
+- Identity Mappings in Deep Residual Networks (2016), K. He et al. *(Microsoft)* [[pdf]](https://arxiv.org/pdf/1603.05027v2.pdf)
 
 ### Distinguished Researchers
 *Distinguished deep learning researchers who have published +3 (:sparkles: +6) papers which are on the awesome list*


### PR DESCRIPTION
"Identity Mappings in Deep Residual Networks" is a follow up on "Deep residual learning for image recognition" in which the authors expand their ideas. They are able to effectively train a 1000 layer deep CNN on CIFAR-10 and CIFAR-100 achieving state of the art results. Due to the current lack of citations it only qualifies as a paper worth reading, but it is already mentioned in the course notes of Stanford's CS231n: https://cs231n.github.io/convolutional-networks/#case