### PR TITLE
Removes one duplicate Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Total 85 papers except for the papers in *Hardware / Software*, *Papers Worth Re
 - An analysis of single-layer networks in unsupervised feature learning (2011), A. Coates et al. [[pdf]](http://machinelearning.wustl.edu/mlpapers/paper_files/AISTATS2011_CoatesNL11.pdf)
 - Stacked denoising autoencoders: Learning useful representations in a deep network with a local denoising criterion (2010), P. Vincent et al. *(Bengio)* [[pdf]](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.297.3484&rep=rep1&type=pdf)
 - A practical guide to training restricted boltzmann machines (2010), G. Hinton [[pdf]](http://www.csri.utoronto.ca/~hinton/absps/guideTR.pdf)
-- Stacked denoising autoencoders: Learning useful representations in a deep network with a local denoising criterion (2010), P. Vincent et al. *(Bengio)* [[pdf]](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.297.3484&rep=rep1&type=pdf)
+
 
 ### Hardware / Software
 - TensorFlow: Large-scale machine learning on heterogeneous distributed systems (2016), M. Abadi et al. *(Google)* [[pdf]](http://arxiv.org/pdf/1603.04467)


### PR DESCRIPTION
Removes "Stacked denoising autoencoders: Learning useful representations in a deep network with a local denoising criterion (2010)".