### PR TITLE
added some missing papers from NLProc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - A neural conversational model (2015), O. Vinyals and Q. Le. [[pdf]](https://arxiv.org/pdf/1506.05869.pdf)
 - Transition-Based Dependency Parsing with Stack Long Short-Term Memory (2015), C. Dyer et al., [[pdf]](http://aclweb.org/anthology/P/P15/P15-1033.pdf)
 - Improved Transition-Based Parsing by Modeling Characters instead of Words with LSTMs (2015), M. Ballesteros et al., [[pdf]](http://aclweb.org/anthology/D/D15/D15-1041.pdf)
+- Finding function in form: Compositional character models for open vocabulary word representation (2015), W. Ling et al., [[pdf]] (http://aclweb.org/anthology/D/D15/D15-1176.pdf)
 
 
 *(~2014)*

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 <!---[Key researchers]  [Alex Graves](https://scholar.google.ca/citations?user=DaFHynwAAAAJ)-->
 
-### Natural Language Process
-- **A character-level decoder without explicit segmentation for neural machine translation** (2016), J. Chung et al. [[pdf]](https://arxiv.org/pdf/1603.06147)
+### Natural Language Processing
+- **Neural Architectures for Named Entity Recognition** (2016), G. Lample et al. [[pdf]]
+ (http://aclweb.org/anthology/N/N16/N16-1030.pdf)
 - **Exploring the limits of language modeling** (2016), R. Jozefowicz et al. [[pdf]](http://arxiv.org/pdf/1602.02410)
 - **Teaching machines to read and comprehend** (2015), K. Hermann et al. [[pdf]](http://papers.nips.cc/paper/5945-teaching-machines-to-read-and-comprehend.pdf)
 - **Effective approaches to attention-based neural machine translation** (2015), M. Luong et al. [[pdf]](https://arxiv.org/pdf/1508.04025)
@@ -277,6 +278,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 ### Appendix: More than Top 100
 *(2016)*
+- A character-level decoder without explicit segmentation for neural machine translation (2016), J. Chung et al. [[pdf]](https://arxiv.org/pdf/1603.06147)
 - Dermatologist-level classification of skin cancer with deep neural networks (2017), A. Esteva et al. [[html]](http://www.nature.com/nature/journal/v542/n7639/full/nature21056.html)
 - Weakly supervised object localization with multi-fold multiple instance learning (2017), R. Gokberk et al. [[pdf]](https://arxiv.org/pdf/1503.00949)
 - Brain tumor segmentation with deep neural networks (2017), M. Havaei et al. [[pdf]](https://arxiv.org/pdf/1505.03540)
@@ -303,7 +305,6 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - Generative Short Term Stochastic Gibbs Networks 2016), I. Lenz et al. [[pdf]](https://arxiv.org/pdf/1301.3592)
 
 *(2015)*
-
 - Spatial transformer network (2015), M. Jaderberg et al., [[pdf]](http://papers.nips.cc/paper/5854-spatial-transformer-networks.pdf)
 - Ask your neurons: A neural-based approach to answering questions about images (2015), M. Malinowski et al. [[pdf]](http://www.cv-foundation.org/openaccess/content_iccv_2015/papers/Malinowski_Ask_Your_Neurons_ICCV_2015_paper.pdf)
 - Exploring models and data for image question answering (2015), M. Ren et al. [[pdf]](http://papers.nips.cc/paper/5640-stochastic-variational-inference-for-hidden-markov-models.pdf)
@@ -333,6 +334,9 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - End-to-end memory networks (2015), S. Sukbaatar et al. [[pdf]](http://papers.nips.cc/paper/5846-end-to-end-memory-networks.pdf)
 - Describing videos by exploiting temporal structure (2015), L. Yao et al. [[pdf]](http://www.cv-foundation.org/openaccess/content_iccv_2015/papers/Yao_Describing_Videos_by_ICCV_2015_paper.pdf)
 - A neural conversational model (2015), O. Vinyals and Q. Le. [[pdf]](https://arxiv.org/pdf/1506.05869.pdf)
+- Transition-Based Dependency Parsing with Stack Long Short-Term Memory (2015), C. Dyer et al., [[pdf]](http://aclweb.org/anthology/P/P15/P15-1033.pdf)
+- Improved Transition-Based Parsing by Modeling Characters instead of Words with LSTMs (2015), M. Ballesteros et al., [[pdf]](http://aclweb.org/anthology/D/D15/D15-1041.pdf)
+
 
 *(~2014)*
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - End-to-end memory networks (2015), S. Sukbaatar et al. [[pdf]](http://papers.nips.cc/paper/5846-end-to-end-memory-networks.pdf)
 - Describing videos by exploiting temporal structure (2015), L. Yao et al. [[pdf]](http://www.cv-foundation.org/openaccess/content_iccv_2015/papers/Yao_Describing_Videos_by_ICCV_2015_paper.pdf)
 - A neural conversational model (2015), O. Vinyals and Q. Le. [[pdf]](https://arxiv.org/pdf/1506.05869.pdf)
+- Improving distributional similarity with lessons learned from word embeddings, O. Levy et al., [[pdf]] (https://www.transacl.org/ojs/index.php/tacl/article/download/570/124)
 - Transition-Based Dependency Parsing with Stack Long Short-Term Memory (2015), C. Dyer et al., [[pdf]](http://aclweb.org/anthology/P/P15/P15-1033.pdf)
 - Improved Transition-Based Parsing by Modeling Characters instead of Words with LSTMs (2015), M. Ballesteros et al., [[pdf]](http://aclweb.org/anthology/D/D15/D15-1041.pdf)
 - Finding function in form: Compositional character models for open vocabulary word representation (2015), W. Ling et al., [[pdf]] (http://aclweb.org/anthology/D/D15/D15-1176.pdf)

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - Learning Hierarchical Features for Scene Labeling (2013), C. Farabet et al. [[pdf]](https://hal-enpc.archives-ouvertes.fr/docs/00/74/20/77/PDF/farabet-pami-13.pdf)
 - Linguistic Regularities in Continuous Space Word Representations (2013), T. Mikolov et al. [[pdf]](http://www.aclweb.org/anthology/N13-1#page=784)
 - Large scale distributed deep networks (2012), J. Dean et al. [[pdf]](http://papers.nips.cc/paper/4687-large-scale-distributed-deep-networks.pdf)
+- A Fast and Accurate Dependency Parser using Neural Networks. Chen and Manning. [[pdf]] (http://cs.stanford.edu/people/danqi/papers/emnlp2014.pdf)
 
 
 


### PR DESCRIPTION
Lample et al 2016 has been cited 74 times (and thus has more citations than Chung et al.)
Chen and Manning 2014 has 408 citations.
Levy et al. 2015 has 220 citations.
Dyer et al. 2015 has 174 citations.
Ballesteros et al. 2015 has 74 citations
Ling et al. 100 citations
