### PR TITLE
Moving "Training Very Deep Networks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 <!---[Key researchers]  [Geoffrey Hinton](https://scholar.google.ca/citations?user=JicYPdAAAAAJ), [Yoshua Bengio](https://scholar.google.ca/citations?user=kukA0LcAAAAJ), [Jason Yosinski](https://scholar.google.ca/citations?hl=en&user=gxL1qj8AAAAJ) -->
 
 ### Optimization / Training Techniques
+- **Training very deep networks** (2015), R. Srivastava et al. [[pdf]](http://papers.nips.cc/paper/5850-training-very-deep-networks.pdf)
 - **Batch normalization: Accelerating deep network training by reducing internal covariate shift** (2015), S. Loffe and C. Szegedy [[pdf]](http://arxiv.org/pdf/1502.03167)
 - **Delving deep into rectifiers: Surpassing human-level performance on imagenet classification** (2015), K. He et al. [[pdf]](http://www.cv-foundation.org/openaccess/content_iccv_2015/papers/He_Delving_Deep_into_ICCV_2015_paper.pdf)
 - **Dropout: A simple way to prevent neural networks from overfitting** (2014), N. Srivastava et al. [[pdf]](http://jmlr.org/papers/volume15/srivastava14a/srivastava14a.pdf)
@@ -337,7 +338,6 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - Learning spatiotemporal features with 3d convolutional networks (2015), D. Tran et al. [[pdf]](http://www.cv-foundation.org/openaccess/content_iccv_2015/papers/Tran_Learning_Spatiotemporal_Features_ICCV_2015_paper.pdf)
 - Understanding neural networks through deep visualization (2015), J. Yosinski et al. [[pdf]](https://arxiv.org/pdf/1506.06579)
 - An Empirical Exploration of Recurrent Network Architectures (2015), R. Jozefowicz et al.  [[pdf]](http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf)
-- Training very deep networks (2015), R. Srivastava et al. [[pdf]](http://papers.nips.cc/paper/5850-training-very-deep-networks.pdf)
 - Deep generative image models using a￼ laplacian pyramid of adversarial networks (2015), E.Denton et al. [[pdf]](http://papers.nips.cc/paper/5773-deep-generative-image-models-using-a-laplacian-pyramid-of-adversarial-networks.pdf)
 - Gated Feedback Recurrent Neural Networks (2015), J. Chung et al. [[pdf]](http://www.jmlr.org/proceedings/papers/v37/chung15.pdf)
 - Fast and accurate deep network learning by exponential linear units (ELUS) (2015), D. Clevert et al. [[pdf]](https://arxiv.org/pdf/1511.07289.pdf%5Cnhttp://arxiv.org/abs/1511.07289%5Cnhttp://arxiv.org/abs/1511.07289)

--- a/top100papers.bib
+++ b/top100papers.bib
@@ -48,6 +48,15 @@
   pages={647--655},
   year={2014}
 }
+
+@inproceedings{srivastava2015training,
+  title={Training very deep networks},
+  author={Srivastava, Rupesh K and Greff, Klaus and Schmidhuber, J{\"u}rgen},
+  booktitle={Advances in neural information processing systems},
+  pages={2377--2385},
+  year={2015}
+}
+
 @article{ioffe2015batch,
   title={Batch normalization: Accelerating deep network training by reducing internal covariate shift},
   author={Ioffe, Sergey and Szegedy, Christian},


### PR DESCRIPTION
Our paper "Training Very Deep Networks" (NIPS 2015) is currently in the Appendix section since it has <200 citations. I propose that it should be moved to the main list.

Details:
This paper is an extension of "Highway Networks" which appeared earlier at ICML DL workshop 2015. This is noted in the PDF: https://arxiv.org/pdf/1505.00387.pdf

Many authors prefer to cite the earliest paper, while others cite the NIPS version. There are some duplicates, but together these papers have over 300 citations as shown here:
- [Link to Training Very Deep Networks on Scholar](https://scholar.google.ch/citations?view_op=view_citation&hl=en&user=vTWuk1gAAAAJ&citation_for_view=vTWuk1gAAAAJ:WA5NYHcadZ8C)
- [Link to Highway Networks on Scholar](https://scholar.google.ch/citations?view_op=view_citation&hl=en&user=vTWuk1gAAAAJ&citation_for_view=vTWuk1gAAAAJ:t6usbXjVLHcC)

Additionally, this paper has had wide impact: it is a predecessor of residual networks, demonstrates the relation between deep feedforward networks and LSTM networks, and is used in leading models for language modeling, NMT, speech recognition and generation etc. Therefore, I propose that it is reasonable to include this paper in the main list, as done in this PR.