### PR TITLE
Added RetinaNet paper and a few empty lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To get the news for newly released papers everyday, follow my [twitter](https://
 4. Please refer to *New Papers* and *Old Papers* sections for the papers published in recent 6 months or before 2012.
 
 *(Citation criteria)*
+
 - **< 6 months** : *New Papers* (by discussion)
 - **2016** :  +60 citations or "More Papers from 2016"
 - **2015** :  +200 citations
@@ -210,6 +211,8 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 ### New papers
 *Newly published papers (< 6 months) which are worth reading*
+
+- Focal Loss for Dense Object Detection (2017), T.-Y. Lin et al. [[pdf]](https://arxiv.org/abs/1708.02002)
 - MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications (2017), Andrew G. Howard et al. [[pdf]](https://arxiv.org/pdf/1704.04861.pdf)
 - Convolutional Sequence to Sequence Learning (2017), Jonas Gehring et al. [[pdf]](https://arxiv.org/pdf/1705.03122)
 - A Knowledge-Grounded Neural Conversation Model (2017), Marjan Ghazvininejad et al. [[pdf]](https://arxiv.org/pdf/1702.01932)
@@ -230,6 +233,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 ### Old Papers
 *Classic papers published before 2012*
+
 - An analysis of single-layer networks in unsupervised feature learning (2011), A. Coates et al. [[pdf]](http://machinelearning.wustl.edu/mlpapers/paper_files/AISTATS2011_CoatesNL11.pdf)
 - Deep sparse rectifier neural networks (2011), X. Glorot et al. [[pdf]](http://machinelearning.wustl.edu/mlpapers/paper_files/AISTATS2011_GlorotBB11.pdf)
 - Natural language processing (almost) from scratch (2011), R. Collobert et al. [[pdf]](http://arxiv.org/pdf/1103.0398)
@@ -249,6 +253,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 
 ### HW / SW / Dataset
+
 -  SQuAD: 100,000+ Questions for Machine Comprehension of Text (2016), Rajpurkar et al. [[pdf]](https://arxiv.org/pdf/1606.05250.pdf)
 - OpenAI gym (2016), G. Brockman et al. [[pdf]](https://arxiv.org/pdf/1606.01540)
 - TensorFlow: Large-scale machine learning on heterogeneous distributed systems (2016), M. Abadi et al. [[pdf]](http://arxiv.org/pdf/1603.04467)
@@ -260,6 +265,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 
 ### Book / Survey / Review
+
 - On the Origin of Deep Learning (2017), H. Wang and Bhiksha Raj. [[pdf]](https://arxiv.org/pdf/1702.07800)
 - Deep Reinforcement Learning: An Overview (2017), Y. Li, [[pdf]](http://arxiv.org/pdf/1701.07274v2.pdf)
 - Neural Machine Translation and Sequence-to-sequence Models(2017): A Tutorial, G. Neubig. [[pdf]](http://arxiv.org/pdf/1703.01619v1.pdf)
@@ -274,11 +280,13 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 ### Video Lectures / Tutorials / Blogs
 
 *(Lectures)*
+
 - CS231n, Convolutional Neural Networks for Visual Recognition, Stanford University [[web]](http://cs231n.stanford.edu/)
 - CS224d, Deep Learning for Natural Language Processing, Stanford University [[web]](http://cs224d.stanford.edu/)
 - Oxford Deep NLP 2017, Deep Learning for Natural Language Processing, University of Oxford [[web]](https://github.com/oxford-cs-deepnlp-2017/lectures)
 
 *(Tutorials)*
+
 - NIPS 2016 Tutorials, Long Beach [[web]](https://nips.cc/Conferences/2016/Schedule?type=Tutorial)
 - ICML 2016 Tutorials, New York City [[web]](http://techtalks.tv/icml/2016/tutorials/)
 - ICLR 2016 Videos, San Juan [[web]](http://videolectures.net/iclr2016_san_juan/)
@@ -286,6 +294,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - Bay Area Deep Learning School 2016, Stanford [[web]](https://www.bayareadlschool.org/)
 
 *(Blogs)*
+
 - OpenAI [[web]](https://www.openai.com/)
 - Distill [[web]](http://distill.pub/)
 - Andrej Karpathy Blog [[web]](http://karpathy.github.io/)
@@ -296,6 +305,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 ### Appendix: More than Top 100
 *(2016)*
+
 - A character-level decoder without explicit segmentation for neural machine translation (2016), J. Chung et al. [[pdf]](https://arxiv.org/pdf/1603.06147)
 - Dermatologist-level classification of skin cancer with deep neural networks (2017), A. Esteva et al. [[html]](http://www.nature.com/nature/journal/v542/n7639/full/nature21056.html)
 - Weakly supervised object localization with multi-fold multiple instance learning (2017), R. Gokberk et al. [[pdf]](https://arxiv.org/pdf/1503.00949)
@@ -324,6 +334,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - Consistency and Fluctuations For Stochastic Gradient Langevin Dynamics (2016), Yee Whye Teh et al. [[pdf]](http://www.jmlr.org/papers/volume17/teh16a/teh16a.pdf)
 
 *(2015)*
+
 - Ask your neurons: A neural-based approach to answering questions about images (2015), M. Malinowski et al. [[pdf]](http://www.cv-foundation.org/openaccess/content_iccv_2015/papers/Malinowski_Ask_Your_Neurons_ICCV_2015_paper.pdf)
 - Exploring models and data for image question answering (2015), M. Ren et al. [[pdf]](http://papers.nips.cc/paper/5640-stochastic-variational-inference-for-hidden-markov-models.pdf)
 - Are you talking to a machine? dataset and methods for multilingual image question (2015), H. Gao et al. [[pdf]](http://papers.nips.cc/paper/5641-are-you-talking-to-a-machine-dataset-and-methods-for-multilingual-image-question.pdf)
@@ -358,6 +369,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 
 
 *(~2014)*
+
 - DeepPose: Human pose estimation via deep neural networks (2014), A. Toshev and C. Szegedy [[pdf]](http://www.cv-foundation.org/openaccess/content_cvpr_2014/papers/Toshev_DeepPose_Human_Pose_2014_CVPR_paper.pdf)
 - Learning a Deep Convolutional Network for Image Super-Resolution (2014, C. Dong et al. [[pdf]](https://www.researchgate.net/profile/Chen_Change_Loy/publication/264552416_Lecture_Notes_in_Computer_Science/links/53e583e50cf25d674e9c280e.pdf)
 - Recurrent models of visual attention (2014), V. Mnih et al. [[pdf]](http://arxiv.org/pdf/1406.6247.pdf)


### PR DESCRIPTION
- Added the RetinaNet paper (https://arxiv.org/abs/1708.02002) in the new paper worth reading section. It was submitted in Aug 2017 already have 17 citations, the architecture showed substantial improvements over F-RNN and SSD
- Added a few separating empty lines between section head and lists (it is more compatible with other markdown formats to do so)