### PR TITLE
add JHU NLP course

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ If you have any suggestions (missing papers, new papers, key researchers or typo
 - CS231n, Convolutional Neural Networks for Visual Recognition, Stanford University [[web]](http://cs231n.stanford.edu/)
 - CS224d, Deep Learning for Natural Language Processing, Stanford University [[web]](http://cs224d.stanford.edu/)
 - Oxford Deep NLP 2017, Deep Learning for Natural Language Processing, University of Oxford [[web]](https://github.com/oxford-cs-deepnlp-2017/lectures)
+- JHU CS 601.465, Natural Language Processing, Johns Hopkins University [[web]](http://www.cs.jhu.edu/~jason/465/)
 
 *(Tutorials)*
 - NIPS 2016 Tutorials, Long Beach [[web]](https://nips.cc/Conferences/2016/Schedule?type=Tutorial)


### PR DESCRIPTION
I am currently a student at Johns Hopkins University, and just completed our NLP course taught by Jason Eisner (http://www.cs.jhu.edu/~jason/). Jason is an incredible professor, both in the depth of his knowledge and ability to present engaging material. The course focuses more on the bare-bones of NLP such as semantics, bottom up parsing techniques with speed up hacks, and finite state transducers to name a few, instead of taking a deep learning approach.